### PR TITLE
Fix page view event missing pageUrl parameter

### DIFF
--- a/Sources/segmentify/SegmentifyManager.swift
+++ b/Sources/segmentify/SegmentifyManager.swift
@@ -1687,6 +1687,9 @@ public class SegmentifyManager : NSObject {
         if segmentifyObject.testMode != nil {
             eventRequest.testMode = segmentifyObject.testMode
         }
+        if segmentifyObject.pageUrl != nil {
+            eventRequest.pageUrl = segmentifyObject.pageUrl
+        }
         if segmentifyObject.params != nil {
             eventRequest.params = segmentifyObject.params
         }


### PR DESCRIPTION
Android SDK'sında pageUrl bu event'e ekleniyor anca iOS'te gözden kaçmış. Bir müşterimiz için bu fix e ihtiyacımız var. 